### PR TITLE
replace dispatcher fire method to dispatch method and upgrade to lara…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.idea
 /.DS_Store
 /vendor
+/composer.lock
+/.env
+/tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,12 @@ All Notable changes to `laravel-sls` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## NEXT - YYYY-MM-DD
+## 2020-10-15
 
-### Added
-- Nothing
-
-### Deprecated
-- Nothing
+### Changed
+- Upgrade dependency version to higher.
 
 ### Fixed
-- Nothing
+- Dispatcher's `fire` method had deprecated and replaced by `dispatch` method. Ref: https://github.com/laravel/framework/pull/26392
 
-### Removed
-- Nothing
 
-### Security
-- Nothing

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add following service providers into your providers array in `config/app.php`
 ),
 ```
 
-If you’re need Log you can replace Log alias in your config/app.php
+If you’re need `Log` you can replace `Log` alias in your config/app.php
 ```php
 //'Log'               => Illuminate\Support\Facades\Log::class,
 'Log'                 => Lokielse\LaravelSLS\Facades\SLSLogWriter::class,

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     }
   ],
   "require": {
-    "illuminate/support": "~5.1|~6.0|~7.0",
-    "php": ">=5.5",
+    "illuminate/support": "~6.0||~7.0",
+    "php": ">=7.2",
     "lokielse/aliyun-open-api-sls": "^1.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0||~5.0",
+    "phpunit/phpunit": "^6.0",
     "scrutinizer/ocular": "~1.1",
     "squizlabs/php_codesniffer": "~2.3"
   },

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -229,7 +229,7 @@ class Writer implements PsrLoggerInterface
         // log listeners. These are useful for building profilers or other tools
         // that aggregate all of the log messages for a given "request" cycle.
         if (isset( $this->dispatcher )) {
-            $this->dispatcher->fire('illuminate.log', compact('level', 'message', 'context'));
+            $this->dispatcher->dispatch('illuminate.log', compact('level', 'message', 'context'));
         }
     }
 


### PR DESCRIPTION
朋友，请更新个版本吧，原来的包不支持 laravel 5.8 以上的版本，laravel 5.8 已经将`Event`中的`fire`方法删除了，请参考https://github.com/laravel/framework/pull/26392， 代之以`dispatch`方法